### PR TITLE
bugfix to track caller inst

### DIFF
--- a/src/runtime/ProfilingModules/DependenceWithContextModule.cpp
+++ b/src/runtime/ProfilingModules/DependenceWithContextModule.cpp
@@ -190,16 +190,28 @@ void DependenceWithContextModule::loop_exit() __attribute__((always_inline)) {
   nested_level--;
 }
 
-void DependenceWithContextModule::func_entry(uint32_t instr) {
-  if (nested_level == 1) {
+//void DependenceWithContextModule::func_entry(uint32_t instr) {
+//  if (nested_level == 1) {
+//    context = instr;
+//  }
+//}
+//
+//void DependenceWithContextModule::func_exit(uint32_t instr) {
+//  if (nested_level == 1) {
+//    context = 0;
+//  }
+//}
+
+void DependenceWithContextModule::push(uint32_t instr) __attribute__((always_inline)) {
+  if(func_level == 0)
     context = instr;
-  }
+  func_level++;
 }
 
-void DependenceWithContextModule::func_exit(uint32_t instr) {
-  if (nested_level == 1) {
+void DependenceWithContextModule::pop() __attribute__((always_inline)) {
+  func_level--;
+  if(func_level == 0)
     context = 0;
-  }
 }
 
 void DependenceWithContextModule::merge_dep(DependenceWithContextModule &other) {

--- a/src/runtime/ProfilingModules/DependenceWithContextModule.h
+++ b/src/runtime/ProfilingModules/DependenceWithContextModule.h
@@ -37,6 +37,7 @@ private:
 
   unsigned int context = 0;
   int nested_level = 0;
+  int func_level = 0;
 
 #ifdef COLLECT_TRACE
   // Collect trace
@@ -80,8 +81,11 @@ public:
   void loop_invoc();
   void loop_iter();
   void loop_exit();
-  void func_entry(uint32_t context);
-  void func_exit(uint32_t context);
+  //void func_entry(uint32_t context);
+  //void func_exit(uint32_t context);
+  //FIXME: do we also need ext_push/pop?
+  void push(uint32_t instr);
+  void pop();
 
   void merge_dep(DependenceWithContextModule &other);
 };


### PR DESCRIPTION
added push/pop to track the outermost call inst (do not track nested calls)

TODO:
- add configs to api.yaml, DepModule_TrackContext_Events.yaml (push, pop)
- add implementation (SLAMP_push, SLAMP_pop) to frontend.cpp
