### PR TITLE
Use the right event for dep mod with context

### DIFF
--- a/src/runtime/Events/configs/DepModule_TrackContext_Events.yaml
+++ b/src/runtime/Events/configs/DepModule_TrackContext_Events.yaml
@@ -10,6 +10,9 @@ events:
   target_loop_invoc: []
   target_loop_iter: []
   target_loop_exit: []
-  func_entry: [function_id] # optional if tracking context
-  func_exit: [function_id] # optional if tracking context
+  func_call_push: [inst_id] # optional if tracking context
+  func_call_pop: [] # optional if tracking context
   finished: []
+
+  # func_entry: [function_id] # optional if tracking context
+  # func_exit: [function_id] # optional if tracking context

--- a/src/runtime/Events/configs/api.yaml
+++ b/src/runtime/Events/configs/api.yaml
@@ -47,6 +47,10 @@ events:
     function_id: 32
   func_exit:
     function_id: 32
+  func_call_push:
+    inst_id: 32
+  func_call_pop:
+    # no arg
   points_to_inst:
     inst_id: 32
     ptr: 64

--- a/src/runtime/ProfilingModules/DependenceWithContextModule.cpp
+++ b/src/runtime/ProfilingModules/DependenceWithContextModule.cpp
@@ -191,13 +191,15 @@ void DependenceWithContextModule::loop_exit() __attribute__((always_inline)) {
 }
 
 void DependenceWithContextModule::func_entry(uint32_t instr) {
-  if (nested_level == 1) {
+  if(callgraph_level == 0) {
     context = instr;
   }
+  callgraph_level++;
 }
 
 void DependenceWithContextModule::func_exit(uint32_t instr) {
-  if (nested_level == 1) {
+  callgraph_level--;
+  if(callgraph_level == 0) {
     context = 0;
   }
 }

--- a/src/runtime/ProfilingModules/DependenceWithContextModule.h
+++ b/src/runtime/ProfilingModules/DependenceWithContextModule.h
@@ -37,6 +37,7 @@ private:
 
   unsigned int context = 0;
   int nested_level = 0;
+  int callgraph_level = 0;
 
 #ifdef COLLECT_TRACE
   // Collect trace

--- a/src/runtime/frontend/custom_produce.h
+++ b/src/runtime/frontend/custom_produce.h
@@ -23,6 +23,8 @@ enum UnifiedAction : char {
   FUNC_EXIT,
   POINTS_TO_INST,
   POINTS_TO_ARG,
+  FUNC_CALL_PUSH,
+  FUNC_CALL_POP,
   FINISHED
 };
 

--- a/src/runtime/frontend/frontend.cpp
+++ b/src/runtime/frontend/frontend.cpp
@@ -102,6 +102,14 @@ static uint32_t ext_fn_inst_id = 0;
 #define PRODUCE_STORE(size, instr, addr)
 #endif
 
+#ifndef PRODUCE_FUNC_CALL_PUSH
+#define PRODUCE_FUNC_CALL_PUSH(inst_id)
+#endif
+
+#ifndef PRODUCE_FUNC_CALL_POP
+#define PRODUCE_FUNC_CALL_POP()
+#endif
+
 static volatile char *lc_dummy = NULL;
 
 PRODUCE_QUEUE_DEFINE();
@@ -342,8 +350,9 @@ void memalign_callback(void *ptr, size_t alignment, size_t size) {
 
 // FIXME: a bunch of unused functions
 void SLAMP_main_entry(uint32_t argc, char **argv, char **env) {}
-void SLAMP_push(const uint32_t instr) {}
-void SLAMP_pop() {}
+void SLAMP_push(const uint32_t instr) { PRODUCE_FUNC_CALL_PUSH(instr); }
+void SLAMP_pop() { PRODUCE_FUNC_CALL_POP(); }
+
 void SLAMP_allocated(uint64_t addr) {}
 
 void SLAMP_callback_stack_alloca(uint32_t instr, void *ptr, uint64_t array_size,

--- a/src/runtime/frontend/frontend.cpp
+++ b/src/runtime/frontend/frontend.cpp
@@ -350,8 +350,8 @@ void memalign_callback(void *ptr, size_t alignment, size_t size) {
 
 // FIXME: a bunch of unused functions
 void SLAMP_main_entry(uint32_t argc, char **argv, char **env) {}
-void SLAMP_push(const uint32_t instr) { PRODUCE_FUNC_CALL_PUSH(instr); }
-void SLAMP_pop() { PRODUCE_FUNC_CALL_POP(); }
+void SLAMP_push(const uint32_t instr) { if(on_profiling) PRODUCE_FUNC_CALL_PUSH(instr); }
+void SLAMP_pop() { if(on_profiling) PRODUCE_FUNC_CALL_POP(); }
 
 void SLAMP_allocated(uint64_t addr) {}
 


### PR DESCRIPTION
Use slamp_push and slamp_pop instead of function call for dep mod with context

The reasoning is we need to track the caller id rather than the callee (function) ID to uniquely identify the dependence in the original loop context.